### PR TITLE
Use curator for druid node discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ this method supports auto detection and update of available brokers for easy HA/
 ```clj
 (use 'clj-druid.client)
 (connect {:zk {:host "127.0.0.1:2181"
-               :discovery-path "/druid/discovery"}})
+               :discovery-path "/druid/discovery"
+               :node-type "broker"}})
 ```
 
 you can also connect by supplying a vector of hosts, useful for dev, local testing
@@ -64,8 +65,11 @@ Issue druid queries supplying
                {:type :fieldAccess :name "sample_name2" :fieldName "sample_fieldName2"}]}]
 
    :intervals ["2012-01-01T00:00:00.000/2012-01-03T00:00:00.000"]})
-   
-   (query random (:queryType q) q) 
+   (let [client (connect {:zk {:host "127.0.0.1:2181"
+                          :discovery-path "/druid/discovery"
+                          :node-type "broker"}})]
+     (query client random (:queryType q) q)
+     (close client))
 ```
    
 ### Example

--- a/examples/src/handler.clj
+++ b/examples/src/handler.clj
@@ -7,10 +7,11 @@
 
 
 (def default-druid-host "http://localhost:8083/druid/v2")
-(client/connect {:hosts [default-druid-host]})
+(def druid-client (client/connect {:hosts [default-druid-host]}))
 
 (defn do-query [q]
   (ok (client/query
+       druid-client
        client/randomized
        (:queryType q) q)))
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject y42/clj-druid "0.2.12"
+(defproject y42/clj-druid "0.2.13-SNAPSHOT"
   :description "Clojure library for Druid.io"
   :url "http://github.com/y42/clj-druid"
   :license {:name "Eclipse Public License"
@@ -15,4 +15,4 @@
                  [prismatic/schema "1.0.4"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/data.json "0.2.6"]
-                 [zookeeper-clj "0.9.1"]])
+                 [curator "0.0.6"]])

--- a/test/clj_druid/client_test.clj
+++ b/test/clj_druid/client_test.clj
@@ -4,20 +4,23 @@
             [clj-druid.client :refer :all]))
 
 (deftest ^:integration test-connect-zookeeper
-  (connect {:zk {:host "127.0.0.1:2181"
-                 :discovery-path "/druid/discovery"
-                 :node-type "broker"}}))
+  (let [client (connect {:zk {:host "127.0.0.1:2181"
+                        :discovery-path "/druid/discovery"
+                              :node-type "broker"}})]
+    (close client)))
 
 (deftest ^:integration test-connect-user
-  (connect {:hosts ["http://localhost:8082/druid/v2/"]}))
+  (let [client (connect {:hosts ["http://localhost:8082/druid/v2/"]})]
+    (close client)))
 
 (deftest ^:integration test-zk-query
-  (connect {:zk {:host "127.0.0.1:2181"
-                 :discovery-path "/druid/discovery"
-                 :node-type "broker"}})
-
-  (query randomized :groupBy f/valid-groupby-query))
+  (let [client (connect {:zk {:host "127.0.0.1:2181"
+                              :discovery-path "/druid/discovery"
+                              :node-type "broker"}})]
+    (query client randomized :groupBy f/valid-groupby-query)
+    (close client)))
 
 (deftest ^:integration test-user-query
-  (connect {:hosts ["http://127.0.0.1:8083/druid/v2/"]})
-  (query randomized :groupBy f/valid-groupby-query :timeout 5000))
+  (let [client (connect {:hosts ["http://127.0.0.1:8083/druid/v2/"]})]
+    (query client randomized :groupBy f/valid-groupby-query :timeout 5000)
+    (close client)))


### PR DESCRIPTION
I've issues when the connection with zookeeper is lost. I didn't find any way to be notified when the connection is lost or when the session expired. The [apache curator library](http://curator.apache.org/curator-client/index.html) makes client access to ZooKeeper much simpler and less error prone. They strongly recommend to use curator instead of using directly CuratorZookeeperClient.
